### PR TITLE
Add --container-name option to ecs-cli logs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -124,10 +124,18 @@ runs:
       run: |
         echo "::group::Retrieve container logs from CloudWatch logs"
         echo '::echo::on'
-        out=$(ecs-cli logs --timestamps \
-          --cluster ${{ inputs.cluster }} \
-          --task-id ${{ steps.run-task.outputs.task_id }} \
-          --task-def ${{ inputs.task-definition-family }}:${{ steps.task-def-register.outputs.revision }})
+        if [ '${{ inputs.container-name }}' != '' ]; then
+          out=$(ecs-cli logs --timestamps \
+            --cluster ${{ inputs.cluster }} \
+            --task-id ${{ steps.run-task.outputs.task_id }} \
+            --task-def ${{ inputs.task-definition-family }}:${{ steps.task-def-register.outputs.revision }} \
+            --container-name ${{ inputs.container-name }})
+        else
+          out=$(ecs-cli logs --timestamps \
+            --cluster ${{ inputs.cluster }} \
+            --task-id ${{ steps.run-task.outputs.task_id }} \
+            --task-def ${{ inputs.task-definition-family }}:${{ steps.task-def-register.outputs.revision }})
+        fi
         out="${out//'%'/'%25'}"
         out="${out//$'\n'/'%0A'}"
         out="${out//$'\r'/'%0D'}"


### PR DESCRIPTION
`ecs-cli logs` failed when I defined multiple containers in a task definition.

```
Failed to get log configuration: Log Configuration Field awslogs-group mismatches in at least one container definition in [arn]. Use the --container-name option to query logs for an individual container.
```