### PR TITLE
Made step possible to wait for ECS tasks that take more than 10 minutes to complete

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -105,10 +105,28 @@ runs:
 
     - name: Wait until a task stopped
       shell: bash
+      env:
+        max_attempt_count: 3
       run: |
-        aws ecs wait tasks-stopped \
-          --cluster ${{ inputs.cluster }} \
-          --tasks ${{ steps.run-task.outputs.task_arn }}
+        attempt_count=0
+        while [ $attempt_count -lt ${{ env.max_attempt_count }} ]
+        do
+          aws ecs wait tasks-stopped \
+            --cluster ${{ inputs.cluster }} \
+            --tasks ${{ steps.run-task.outputs.task_arn }}
+        
+          task_status=$(aws ecs describe-tasks \
+            --cluster ${{ inputs.cluster }} \
+            --tasks ${{ steps.run-task.outputs.task_arn }} \
+            --query "tasks[0].lastStatus" \
+            --output text)
+
+          if [ "${task_status}" = "STOPPED" ];then
+            break
+          fi
+          echo "Waiting for the task to stop... (attempt: $attempt_count)"
+          attempt_count=$((attempt_count+1))
+        done
 
     - name: Install ecs-cli
       shell: bash


### PR DESCRIPTION
Thank you so much for always providing this library. 
I have been a frequent user and deeply appreciate the efforts of the maintainers.

I have identified an issue in the workflow where it fails to properly wait for ECS tasks that take more than 10 minutes to execute, resulting in errors. I have made the necessary modifications to address this problem.

Could you please review my changes?

Feel free to let me know if there are any additional details or adjustments needed.